### PR TITLE
Fix support for capslock mask on OS X.

### DIFF
--- a/src/darwin/input_hook.c
+++ b/src/darwin/input_hook.c
@@ -182,7 +182,7 @@ static void initialize_modifiers() {
 		set_modifier_mask(MASK_BUTTON5);
 	}
 
-	if (CGEventSourceFlagsState(kCGEventFlagMaskAlphaShift)) {
+	if (CGEventSourceFlagsState(kCGEventSourceStateCombinedSessionState) & kCGEventFlagMaskAlphaShift) {
 		set_modifier_mask(MASK_CAPS_LOCK);
 	}
 	// Best I can tell, OS X does not support Num or Scroll lock.


### PR DESCRIPTION
Hi Alex,

This fix is required otherwise the thread is blocked at the same line.

Guessed from: http://stackoverflow.com/questions/32128748/how-to-read-the-state-of-num-lock-using-cocoa-quartz

Tested on OS X 10.11 by running demo_hook_async with/without caps lock.

Best regards,
Christian