### PR TITLE
Fixed compile errors with newer Xcode versions and issue #64

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,5 +20,5 @@ Markus G. Kuhn <mkuhn@acm.org>
 	original version of the keysym_to_unicode function in x11/input_helper.c
 
 Alex <universailp@web.de>
-	updated objc_sendMsg for newer XCode versions
+	updated objc_msgSend for newer XCode versions
 	in darwin/input_hook.c

--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,7 @@ Markus G. Kuhn <mkuhn@acm.org>
 	keysym_unicode_table lookup table in x11/input_helper.c
 	original version of the unicode_to_keysym function in x11/input_helper.c
 	original version of the keysym_to_unicode function in x11/input_helper.c
+
+Alex <universailp@web.de>
+	updated objc_sendMsg for newer XCode versions
+	in darwin/input_hook.c

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Prerequisites: autotools, pkg-config, libtool, gcc, clang or msys2/mingw32
 ### Note for windows compilation
 When using msys2/cygwin make sure to install dos2unix and convert the line endings in ```configure.ac``` and ```configure```
 before running the above.
-You can point [cmake](https://cmake.org) and let it generate files for Visual Studio.
+After running ``bootsrap.sh`` and ``configure`` you can point [cmake](https://cmake.org) to the folder containting this repository and let it generate project files for Visual Studio.
 
 ## Usage
 * [Hook Demo](https://github.com/kwhat/libuiohook/blob/master/src/demo_hook.c)

--- a/src/demo_hook.c
+++ b/src/demo_hook.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <uiohook.h>
+#include <wchar.h>
 
 bool logger_proc(unsigned int level, const char *format, ...) {
 	bool status = false;

--- a/src/demo_hook_async.c
+++ b/src/demo_hook_async.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <uiohook.h>
+#include <wchar.h
 
 #ifdef _WIN32
 #include <windows.h>

--- a/src/demo_hook_async.c
+++ b/src/demo_hook_async.c
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <uiohook.h>
-#include <wchar.h
+#include <wchar.h>
 
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
Since I've had the pleasure of working with macOS in the past weeks for my own projects, I thought I'd try to fix the compile issue with the new Xcode version.
I basically just followed [this](https://stackoverflow.com/a/26737473) solution and tweaked the return value to ``void *``. Some calls to this strong typed version of the function only use two arguments so I just set the fourth one to ``NULL``.
I compiled and tested this on macOS 10.15.3 and it seemed to work without issues. I could only test the ``demo_hook.c`` though because I couldn't be bothered to figure out how to compile the asynchronous one :P

I also fixed #64 and updated the readme, since what I previously wrote there didn't really make any sense.