### PR TITLE
Added the ability to pass captures to the hook dispatcher.

### DIFF
--- a/demo/demo_hook.c
+++ b/demo/demo_hook.c
@@ -56,7 +56,12 @@ bool logger_proc(unsigned int level, const char *format, ...) {
 // Furthermore, some operating systems may choose to disable your hook if it 
 // takes too long to process.  If you need to do any extended processing, please 
 // do so by copying the event to your own queued dispatch thread.
-void dispatch_proc(uiohook_event * const event) {
+void dispatch_proc(uiohook_event * const event, void* capture) {
+    int* event_counter = (int*)capture;
+    printf("%d - ", *event_counter);
+    ++(*event_counter);
+
+
     char buffer[256] = { 0 };
     size_t length = snprintf(buffer, sizeof(buffer), 
             "id=%i,when=%" PRIu64 ",mask=0x%X", 
@@ -128,11 +133,12 @@ void dispatch_proc(uiohook_event * const event) {
 }
 
 int main() {
+    int event_counter = 0;
     // Set the logger callback for library output.
     hook_set_logger_proc(&logger_proc);
     
     // Set the event callback for uiohook events.
-    hook_set_dispatch_proc(&dispatch_proc);
+    hook_set_dispatch_proc(&dispatch_proc, &event_counter);
 
     // Start the hook and block.
     // NOTE If EVENT_HOOK_ENABLED was delivered, the status will always succeed.

--- a/demo/demo_hook_async.c
+++ b/demo/demo_hook_async.c
@@ -86,7 +86,7 @@ bool logger_proc(unsigned int level, const char *format, ...) {
 // Furthermore, some operating systems may choose to disable your hook if it 
 // takes too long to process.  If you need to do any extended processing, please 
 // do so by copying the event to your own queued dispatch thread.
-void dispatch_proc(uiohook_event * const event) {
+void dispatch_proc(uiohook_event * const event, void* capture) {
     char buffer[256] = { 0 };
     size_t length = snprintf(buffer, sizeof(buffer), 
             "id=%i,when=%" PRIu64 ",mask=0x%X", 
@@ -355,7 +355,7 @@ int main() {
     hook_set_logger_proc(&logger_proc);
     
     // Set the event callback for uiohook events.
-    hook_set_dispatch_proc(&dispatch_proc);
+    hook_set_dispatch_proc(&dispatch_proc, NULL);
 
     // Start the hook and block.
     // NOTE If EVENT_HOOK_ENABLED was delivered, the status will always succeed.

--- a/include/uiohook.h
+++ b/include/uiohook.h
@@ -126,7 +126,7 @@ typedef struct _uiohook_event {
     } data;
 } uiohook_event;
 
-typedef void (*dispatcher_t)(uiohook_event *const);
+typedef void (*dispatcher_t)(uiohook_event *const, void* capture);
 /* End Virtual Event Types and Data Structures */
 
 
@@ -421,7 +421,7 @@ extern "C" {
     UIOHOOK_API void hook_post_event(uiohook_event * const event);
 
     // Set the event callback function.
-    UIOHOOK_API void hook_set_dispatch_proc(dispatcher_t dispatch_proc);
+    UIOHOOK_API void hook_set_dispatch_proc(dispatcher_t dispatch_proc, void* capture);
 
     // Insert the event hook.
     UIOHOOK_API int hook_run();

--- a/src/darwin/input_hook.c
+++ b/src/darwin/input_hook.c
@@ -89,12 +89,14 @@ static uiohook_event event;
 
 // Event dispatch callback.
 static dispatcher_t dispatcher = NULL;
+static void* dispatcher_capture = NULL;
 
-UIOHOOK_API void hook_set_dispatch_proc(dispatcher_t dispatch_proc) {
+UIOHOOK_API void hook_set_dispatch_proc(dispatcher_t dispatch_proc, void* capture) {
     logger(LOG_LEVEL_DEBUG, "%s [%u]: Setting new dispatch callback to %#p.\n",
             __FUNCTION__, __LINE__, dispatch_proc);
 
     dispatcher = dispatch_proc;
+    dispatcher_capture = capture;
 }
 
 // Send out an event if a dispatcher was set.
@@ -103,7 +105,7 @@ static inline void dispatch_event(uiohook_event *const event) {
         logger(LOG_LEVEL_DEBUG, "%s [%u]: Dispatching event type %u.\n",
                 __FUNCTION__, __LINE__, event->type);
 
-        dispatcher(event);
+        dispatcher(event, dispatcher_capture);
     } else {
         logger(LOG_LEVEL_WARN, "%s [%u]: No dispatch callback set!\n",
                 __FUNCTION__, __LINE__);

--- a/src/windows/input_hook.c
+++ b/src/windows/input_hook.c
@@ -45,12 +45,14 @@ static uiohook_event event;
 
 // Event dispatch callback.
 static dispatcher_t dispatcher = NULL;
+static void* dispatcher_capture = NULL;
 
-UIOHOOK_API void hook_set_dispatch_proc(dispatcher_t dispatch_proc) {
+UIOHOOK_API void hook_set_dispatch_proc(dispatcher_t dispatch_proc, void* capture) {
     logger(LOG_LEVEL_DEBUG, "%s [%u]: Setting new dispatch callback to %#p.\n",
             __FUNCTION__, __LINE__, dispatch_proc);
 
     dispatcher = dispatch_proc;
+    dispatcher_capture = capture;
 }
 
 // Send out an event if a dispatcher was set.
@@ -59,7 +61,7 @@ static inline void dispatch_event(uiohook_event *const event) {
         logger(LOG_LEVEL_DEBUG, "%s [%u]: Dispatching event type %u.\n",
                 __FUNCTION__, __LINE__, event->type);
 
-        dispatcher(event);
+        dispatcher(event, dispatcher_capture);
     } else {
         logger(LOG_LEVEL_WARN, "%s [%u]: No dispatch callback set!\n",
                 __FUNCTION__, __LINE__);

--- a/src/x11/input_hook.c
+++ b/src/x11/input_hook.c
@@ -101,12 +101,14 @@ static uiohook_event event;
 
 // Event dispatch callback.
 static dispatcher_t dispatcher = NULL;
+static void* dispatcher_capture = NULL;
 
-UIOHOOK_API void hook_set_dispatch_proc(dispatcher_t dispatch_proc) {
+UIOHOOK_API void hook_set_dispatch_proc(dispatcher_t dispatch_proc, void* capture) {
     logger(LOG_LEVEL_DEBUG, "%s [%u]: Setting new dispatch callback to %#p.\n",
             __FUNCTION__, __LINE__, dispatch_proc);
 
     dispatcher = dispatch_proc;
+    dispatcher_capture = capture;
 }
 
 // Send out an event if a dispatcher was set.
@@ -115,7 +117,7 @@ static inline void dispatch_event(uiohook_event *const event) {
         logger(LOG_LEVEL_DEBUG, "%s [%u]: Dispatching event type %u.\n",
                 __FUNCTION__, __LINE__, event->type);
 
-        dispatcher(event);
+        dispatcher(event, dispatcher_capture);
     } else {
         logger(LOG_LEVEL_WARN, "%s [%u]: No dispatch callback set!\n",
                 __FUNCTION__, __LINE__);


### PR DESCRIPTION
This essentially transforms the dispatcher callback into a closure,
you can now take local state, convert it into a void pointer and
pass it to the `hook_set_dispatch_proc`, and the library will pass
the same pointer on each event to the dispatcher where you can transform
the void pointer back to your local variables and read/modify them.

I also updated the basic hook_demo to use this feature to implement a basic event counter: 
https://github.com/Zshoham/libuiohook/blob/8b0b19589c9b8b1a6ac2783977f428474c1e7cb1/demo/demo_hook.c#L60-L62