### PR TITLE
Fixed the search for the foreground window locale in the keycode_to_unicode function

### DIFF
--- a/src/windows/input_helper.c
+++ b/src/windows/input_helper.c
@@ -664,7 +664,7 @@ SIZE_T keycode_to_unicode(DWORD keycode, PWCHAR buffer, SIZE_T size) {
         }
 
         // You may already be a winner!
-        if (locale_item != NULL && locale_item->id != locale_id) {
+        if (locale_item != NULL && locale_item->id == locale_id) {
             logger(LOG_LEVEL_INFO,
                     "%s [%u]: Activating keyboard layout %#p.\n",
                     __FUNCTION__, __LINE__, locale_item->id);


### PR DESCRIPTION
The condition for executing the while-cycle described above is the presence of elements in the list and the locale mismatch.
At this point, we need to check the exit from the list bounds and get confirmation of the match of the desired locale.

I think this code worked because the load_input_helper function calls the refresh_locale_list function, which sets locale_current.
If a new locale is added after the refresh_locale_list function is running, a random (last) locale will be taken in the keycode_to_unicode function and the refresh_locale_list function will not be called again.