### PR TITLE
Add an alternative logger callback which accepts va_list

### DIFF
--- a/include/uiohook.h
+++ b/include/uiohook.h
@@ -60,6 +60,7 @@ typedef enum _log_level {
 
 // Logger callback function prototype.
 typedef bool (*logger_t)(unsigned int, const char *, ...);
+typedef bool (*va_logger_t)(unsigned int, const char *, va_list);
 /* End Log Levels and Function Prototype */
 
 /* Begin Virtual Event Types and Data Structures */
@@ -414,8 +415,11 @@ typedef void (*dispatcher_t)(uiohook_event *const);
 extern "C" {
 #endif
 
-    // Set the logger callback functions.
+    // Set the logger callback function.
     UIOHOOK_API void hook_set_logger_proc(logger_t logger_proc);
+
+    // Set the logger callback function.
+    UIOHOOK_API void hook_set_va_logger_proc(va_logger_t logger_proc);
 
     // Send a virtual event back to the system.
     UIOHOOK_API void hook_post_event(uiohook_event * const event);

--- a/src/logger.c
+++ b/src/logger.c
@@ -28,6 +28,18 @@ static bool default_logger(unsigned int level, const char *format, ...) {
     return false;
 }
 
+static va_logger_t va_logger;
+
+static bool va_logger_wrapper(unsigned int level, const char *format, ...) {
+    va_list args;
+
+    va_start(args, format);
+    bool result = va_logger(level, format, args);
+    va_end(args);
+
+    return result;
+}
+
 // Current logger function pointer, should never be null.
 logger_t logger = &default_logger;
 
@@ -36,5 +48,14 @@ UIOHOOK_API void hook_set_logger_proc(logger_t logger_proc) {
         logger = &default_logger;
     } else {
         logger = logger_proc;
+    }
+}
+
+UIOHOOK_API void hook_set_va_logger_proc(va_logger_t logger_proc) {
+    if (logger_proc == NULL) {
+        logger = &default_logger;
+    } else {
+        va_logger = logger_proc;
+        logger = &va_logger_wrapper;
     }
 }


### PR DESCRIPTION
I've added a new logger callback which accepts va_list instead of varargs. Setting the va_list callback will actually set the normal callback under the hood, so existing code related to logging doesn't need to be changed. I've tested it on Windows and it works without problems.

This PR is basically the same as #125, but from the 1.3 branch.

Closes #124.