### PR TITLE
Fixes issue looking up scancode 30 (a) for Darwin

### DIFF
--- a/src/darwin/post_event.c
+++ b/src/darwin/post_event.c
@@ -111,7 +111,7 @@ static int post_key_event(uiohook_event * const event, CGEventSourceRef src) {
     }
 
     CGKeyCode keycode = (CGKeyCode) scancode_to_keycode(event->data.keyboard.keycode);
-    if (keycode == 0x0000) {
+    if (keycode == kVK_Undefined) {
         logger(LOG_LEVEL_WARN, "%s [%u]: Unable to lookup scancode: %li\n",
                 __FUNCTION__, __LINE__, event->data.keyboard.keycode);
         return UIOHOOK_FAILURE;


### PR DESCRIPTION
Fixes #145 as 0x0000 corresponds to `kVK_ANSI_A` and not `kVK_Undefined`, which is what based on the code should look like