### PR TITLE
Distinguish mouse and touch events

### DIFF
--- a/include/uiohook.h
+++ b/include/uiohook.h
@@ -453,6 +453,7 @@ typedef void (*dispatcher_t)(uiohook_event * const, void *);
 #define MASK_CAPS_LOCK                           1 << 14
 #define MASK_SCROLL_LOCK                         1 << 15
 
+#define MASK_TOUCHED                             1 << 29
 #define MASK_EMULATED                            1 << 30
 #define MASK_CONSUMED                            1 << 31
 /* End Virtual Modifier Masks */

--- a/src/windows/dispatch_event.c
+++ b/src/windows/dispatch_event.c
@@ -23,7 +23,7 @@
 #include "logger.h"
 
 // Flag to recognize touch events: https://stackoverflow.com/questions/45473673/how-to-distinguish-touch-vs-mouse-event-from-setwindowshookex-in-c-sharp
-static int TOUCH_FLAG = 0xFF515700;
+static ULONG_PTR TOUCH_FLAG = 0xFF515700;
 
 // Virtual event pointer.
 static uiohook_event uio_event;
@@ -249,7 +249,7 @@ bool dispatch_button_press(uint64_t timestamp, MSLLHOOKSTRUCT *mshook, uint16_t 
     if (mshook->flags & (LLMHF_INJECTED | LLMHF_LOWER_IL_INJECTED)) {
         uio_event.mask |= MASK_EMULATED;
     }
-    if(mshook->dwExtraInfo & TOUCH_FLAG) {
+    if((mshook->dwExtraInfo & TOUCH_FLAG) == TOUCH_FLAG) {
         uio_event.mask |= MASK_TOUCHED;
     }
 
@@ -281,7 +281,7 @@ bool dispatch_button_release(uint64_t timestamp, MSLLHOOKSTRUCT *mshook, uint16_
     if (mshook->flags & (LLMHF_INJECTED | LLMHF_LOWER_IL_INJECTED)) {
         uio_event.mask |= MASK_EMULATED;
     }
-    if(mshook->dwExtraInfo & TOUCH_FLAG) {
+    if((mshook->dwExtraInfo & TOUCH_FLAG) == TOUCH_FLAG) {
         uio_event.mask |= MASK_TOUCHED;
     }
 
@@ -352,7 +352,7 @@ bool dispatch_mouse_move(uint64_t timestamp, MSLLHOOKSTRUCT *mshook) {
         if (mshook->flags & (LLMHF_INJECTED | LLMHF_LOWER_IL_INJECTED)) {
             uio_event.mask |= MASK_EMULATED;
         }
-        if(mshook->dwExtraInfo & TOUCH_FLAG) {
+        if((mshook->dwExtraInfo & TOUCH_FLAG) == TOUCH_FLAG) {
             uio_event.mask |= MASK_TOUCHED;
         }
 

--- a/src/windows/dispatch_event.c
+++ b/src/windows/dispatch_event.c
@@ -22,6 +22,9 @@
 #include "input_helper.h"
 #include "logger.h"
 
+// Flag to recognize touch events: https://stackoverflow.com/questions/45473673/how-to-distinguish-touch-vs-mouse-event-from-setwindowshookex-in-c-sharp
+static int TOUCH_FLAG = 0xFF515700;
+
 // Virtual event pointer.
 static uiohook_event uio_event;
 
@@ -246,6 +249,9 @@ bool dispatch_button_press(uint64_t timestamp, MSLLHOOKSTRUCT *mshook, uint16_t 
     if (mshook->flags & (LLMHF_INJECTED | LLMHF_LOWER_IL_INJECTED)) {
         uio_event.mask |= MASK_EMULATED;
     }
+    if(mshook->dwExtraInfo & TOUCH_FLAG) {
+        uio_event.mask |= MASK_TOUCHED;
+    }
 
     uio_event.data.mouse.button = button;
     uio_event.data.mouse.clicks = click_count;
@@ -274,6 +280,9 @@ bool dispatch_button_release(uint64_t timestamp, MSLLHOOKSTRUCT *mshook, uint16_
     uio_event.mask = get_modifiers();
     if (mshook->flags & (LLMHF_INJECTED | LLMHF_LOWER_IL_INJECTED)) {
         uio_event.mask |= MASK_EMULATED;
+    }
+    if(mshook->dwExtraInfo & TOUCH_FLAG) {
+        uio_event.mask |= MASK_TOUCHED;
     }
 
     uio_event.data.mouse.button = button;
@@ -342,6 +351,9 @@ bool dispatch_mouse_move(uint64_t timestamp, MSLLHOOKSTRUCT *mshook) {
         uio_event.mask = get_modifiers();
         if (mshook->flags & (LLMHF_INJECTED | LLMHF_LOWER_IL_INJECTED)) {
             uio_event.mask |= MASK_EMULATED;
+        }
+        if(mshook->dwExtraInfo & TOUCH_FLAG) {
+            uio_event.mask |= MASK_TOUCHED;
         }
 
         // Check the modifier mask range for MASK_BUTTON1 - 5.


### PR DESCRIPTION
I am aware that touch events might be out of scope of libuiohook (#62). Nevertheless, there are many touch-devices especially running Windows and it might be handy to distinguish mouse events from touch events. It appears to me that on win32-level these two kind of inputs are mixed together, but there is a flag to check whether an event was caused by a mouse or by a touch: https://stackoverflow.com/questions/45473673/how-to-distinguish-touch-vs-mouse-event-from-setwindowshookex-in-c-sharp

I have drafted a solution for Windows in this pull request. I personally am fine with it functioning on Windows only, yet, I understand if this can only be merged if a solution for macOS and X11 (Wayland?) is found as well.
