### PR TITLE
Dynamically unregister/re-register hooks depending on whether a debugger has been attached

### DIFF
--- a/src/windows/input_hook.c
+++ b/src/windows/input_hook.c
@@ -335,8 +335,6 @@ UIOHOOK_API int hook_run() {
         }
     }
 
-    // Signal the debugger check thread to stop and wait for it
-    g_keep_checking = false;
     if (debugger_thread != NULL) {
         WaitForSingleObject(debugger_thread, INFINITE);
         CloseHandle(debugger_thread);

--- a/src/x11/input_hook.c
+++ b/src/x11/input_hook.c
@@ -138,6 +138,7 @@ void hook_event_proc(XPointer closeure, XRecordInterceptData *recorded_data) {
     }
 
     // TODO There is no way to consume the XRecord event.
+    XRecordFreeData(recorded_data);
 }
 
 static int xrecord_block() {


### PR DESCRIPTION
Refer to https://github.com/kwhat/libuiohook/issues/197 for a detailed explanation of the issue.

At the moment this is purely a proof of concept for what a solution to this issue could look like, please feel free to comment and amend my solution.

- [x] Windows
- [ ] macOS
- [ ] Linux