### PR TITLE
Fix button 2 and 3 when releasing the mouse button on Linux

### DIFF
--- a/src/x11/dispatch_event.c
+++ b/src/x11/dispatch_event.c
@@ -401,7 +401,7 @@ bool dispatch_mouse_press(uint64_t timestamp, XButtonEvent * const x_event) {
 static bool dispatch_mouse_button_released(XButtonReleasedEvent * const x_event) {
     bool consumed = false;
 
-    switch (button_map_lookup(x_event->button)) {
+    switch (x_event->button) {
         case Button1:
             x_event->button = MOUSE_BUTTON1;
             unset_modifier_mask(MASK_BUTTON1);


### PR DESCRIPTION
`button_map_lookup` - a function which swaps button 2 and 3 - is called twice when dispatching the mouse release event. First time at the very beginning of `dispatch_mouse_release`, and then another time in the `switch` statement, which means that buttons 2 and 3 are swapped when dispatching mouse release events on Linux.

This is a problem only on 1.3 - on 1.2 everything looks fine.